### PR TITLE
Socket correction

### DIFF
--- a/specs/AMD-CPUs/Bristol-Ridge.yaml
+++ b/specs/AMD-CPUs/Bristol-Ridge.yaml
@@ -6,7 +6,6 @@ data:
   Lithography: 28 nm
   Sockets:
   - AM4
-  - FM2+
   Foundry: Global Foundries
 sections:
   - header: 7th GEN. QUAD CORE


### PR DESCRIPTION
Removed the FM3+ socket listed under Sockets. Bristol Ridge Athlons are AM4 socket only